### PR TITLE
BUG: use of indices in numpy 1.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 * Deprecations
 * Documentation
 * Bug Fix
+  * Removed chained indices for improved compliance with numpy 1.24 and greater
 * Maintenance
   * Adopted latest pysat development standards.
   * Adopt pytest syntax

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,22 +3,14 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
-[0.3.2] - 2022-05-13
+[0.4.0] - 2023-XX-XX
 --------------------
 * New Features
-  * Compatible with pysat v3.0+
 * Deprecations
 * Documentation
-  * Added pull request templates and other GitHub project documentation.
-  * Switched Windows installation instructions to favor installing WSL.
 * Bug Fix
-  * Improved builds for newer compilers.
-  * Replaces uninterpretable characters with '*' so data loading may continue.
 * Maintenance
   * Adopted latest pysat development standards.
-  * Shifted from TravisCI to GitHub Actions for online testing.
-  * Adopted setup.cfg
-  * Improved PEP8 compliance
   * Adopt pytest syntax
 
 [0.3.2] - 2022-05-13

--- a/pysatCDF/_cdf.py
+++ b/pysatCDF/_cdf.py
@@ -569,7 +569,7 @@ class CDF(object):
                             chars.append('*')
                     self.meta[var_name][attr_name] = ''.join(chars).rstrip()
                 else:
-                    self.meta[var_name][attr_name] = data[i, 0:num_e]
+                    self.meta[var_name][attr_name] = data[i][0:num_e]
 
     def to_pysat(self, flatten_twod=True, units_label='UNITS',
                  name_label='LONG_NAME', fill_label='FILLVAL',


### PR DESCRIPTION
# Description

Addresses #46

numpy 1.24.1 doesn't like how the indices work.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This has only been tested via github actions.  It needs a human in the loop to verify that data is loaded as expected. I cannot compile on my local machine.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors

 If this is a release PR, replace the first item of the above checklist with the
 release checklist on the pysat wiki:
 https://github.com/pysat/pysat/wiki/Checklist-for-Release